### PR TITLE
Proof of Concept for introducing Rector

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,7 +7,8 @@ $finder = PhpCsFixer\Finder::create()
     ])
     ->name('*.php')
     ->ignoreDotFiles(true)
-    ->ignoreVCS(true);
+    ->ignoreVCS(true)
+;
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true);
@@ -21,7 +22,7 @@ $config->setRules([
     'linebreak_after_opening_tag' => true,
     'native_constant_invocation' => false,
     'native_function_invocation' => [
-        "strict" => false,
+        'strict' => false,
     ],
     'blank_line_before_statement' => ['statements' => ['break', 'case', 'continue', 'declare', 'default', 'exit', 'goto', 'return', 'switch', 'throw', 'try']],
     'concat_space' => ['spacing' => 'one'],

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4.0",
         "pestphp/pest": "1.21.2",
-        "phpstan/phpstan": "1.9.x-dev"
+        "phpstan/phpstan": "1.9.x-dev",
+        "rector/rector": "^0.15.13"
     },
     "provide": {
         "psr/simple-cache-implementation": "1.0|2.0|3.0"

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -17,6 +18,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74,
+        LevelSetList::UP_TO_PHP_73,
+        SetList::DEAD_CODE
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ]);
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_74,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -9,8 +9,8 @@ use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
-        __DIR__.'/src',
-        __DIR__.'/tests',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
     ]);
 
     // register a single rule
@@ -19,6 +19,6 @@ return static function (RectorConfig $rectorConfig): void {
     // define sets of rules
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_73,
-        SetList::DEAD_CODE
+        SetList::DEAD_CODE,
     ]);
 };

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -13,8 +13,8 @@ use Symfony\Component\Cache\CacheItem;
  */
 class Client extends BaseClient
 {
-    const CACHE_VERSION_KEY = 'storyblok_cv';
-    const EXCEPTION_GENERIC_HTTP_ERROR = 'An HTTP Error has occurred!';
+    public const CACHE_VERSION_KEY = 'storyblok_cv';
+    public const EXCEPTION_GENERIC_HTTP_ERROR = 'An HTTP Error has occurred!';
 
     /**
      * @var string
@@ -206,8 +206,6 @@ class Client extends BaseClient
      *
      * @param string $driver  Driver
      * @param array  $options Path for file cache
-     *
-     * @return \Storyblok\Client
      */
     public function setCache($driver, $options = []): self
     {
@@ -653,7 +651,7 @@ class Client extends BaseClient
         if (isset($data['rels'])) {
             $relations = $data['rels'];
         } elseif (isset($data['rel_uuids'])) {
-            $relSize = \count($data['rel_uuids']);
+            $relSize = is_countable($data['rel_uuids']) ? \count($data['rel_uuids']) : 0;
             $chunks = [];
             $chunkSize = 50;
 
@@ -694,7 +692,7 @@ class Client extends BaseClient
         if (isset($data['links'])) {
             $links = $data['links'];
         } elseif (isset($data['link_uuids'])) {
-            $linksSize = \count($data['link_uuids']);
+            $linksSize = is_countable($data['link_uuids']) ? \count($data['link_uuids']) : 0;
             $chunks = [];
             $chunkSize = 50;
 
@@ -706,7 +704,7 @@ class Client extends BaseClient
             for ($chunkIndex = 0; $chunkIndex < \count($chunks); ++$chunkIndex) {
                 $linksRes = $this->getStories([
                     'per_page' => $chunkSize,
-                    'language' => isset($queryString['language']) ? $queryString['language'] : 'default',
+                    'language' => $queryString['language'] ?? 'default',
                     'by_uuids' => implode(',', $chunks[$chunkIndex]),
                 ]);
 
@@ -998,7 +996,7 @@ class Client extends BaseClient
         if ($this->isCache()) {
             $cacheItem = $this->cache->getItem($key);
             $cacheItem->set($value);
-            if ('object' === \gettype($value) && 'Storyblok\\Response' === \get_class($value) && \is_array($value->getBody()) && \array_key_exists('cv', $value->getBody())) {
+            if ('object' === \gettype($value) && \Storyblok\Response::class === \get_class($value) && \is_array($value->getBody()) && \array_key_exists('cv', $value->getBody())) {
                 // $cachedCv = $this->cache->getItem(self::CACHE_VERSION_KEY);
                 // $cachedCv->set($value->getBody()['cv']);
                 $this->setCacheVersion(false, $value->getBody()['cv']);

--- a/src/Storyblok/Response.php
+++ b/src/Storyblok/Response.php
@@ -30,7 +30,13 @@ class Response
     public function setBodyFromStreamInterface(StreamInterface $body): self
     {
         $data = (string) $body;
-        $jsonResponseData = (array) json_decode($data, true);
+        $jsonResponseData = null;
+
+        try {
+            $jsonResponseData = (array) json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Exception $e) {
+        }
+
         // return response data as json if possible, raw if not
         $this->httpResponseBody = $data && empty($jsonResponseData) ? $data : $jsonResponseData;
 

--- a/tests/Storyblok/ManagementClientTest.php
+++ b/tests/Storyblok/ManagementClientTest.php
@@ -54,7 +54,7 @@ test('response has proxy', function () {
 
     $post = $client->post('test', []);
     $put = $client->put('test', []);
-    $delete = $client->delete('test', []);
+    $delete = $client->delete('test');
 
     $this->assertEquals('127.0.0.1', $client->getProxy());
     $this->assertEquals(201, $post->httpResponseCode);
@@ -91,5 +91,5 @@ test('delete request throws exception on error', function () {
 
     $this->expectException(ApiException::class);
 
-    $client->delete('test', []);
+    $client->delete('test');
 });


### PR DESCRIPTION
In order to improve the quality of the php-client we introduce in the past:
- PHP Coding Standards Fixer: A tool to automatically fix PHP Coding Standards issues. Thanks to this tool, all the Pull request, and changes in the code base are aligned with the PSR12 standard;
- PestPHP: for automating tests before to merge the Pull Requests.
- PHPStan: for performing the Static code analysis

Today I want to introduce another powerful tool that helps in the refactoring process and helps the developer that wants to create a Pull Request to have a first-level Automated Code Review (checking dead code, using the functionalities provided by the supported PHP versions, early return, type declaration and many more).

The PHP package is `rector/rector` and as the first release the configuration is quite basic:
```
        LevelSetList::UP_TO_PHP_73,
        SetList::DEAD_CODE,
```

Once we introduced and merged this, we can progressivaly add new rules (with specific and dedicated Pull Requests for achieving for example this configuration:

```
        LevelSetList::UP_TO_PHP_73,
        SetList::CODE_QUALITY,
        SetList::DEAD_CODE,
        SetList::EARLY_RETURN,
        SetList::TYPE_DECLARATION,
        SetList::PRIVATIZATION,
```


This is also very useful for when we will decide to drop the support for PHP 7.3.
The tool is useful not just for being sure that the code works after dropping an old release, but it helps us to upgrade the code to use all the new features of the new versions supported (refactoring old code just beacuse we needed them because of the PHP 7.3 supports).

For checking:

```
vendor/bin/rector -n
```

For applying refactor:
```
vendor/bin/rector
```