### PR TITLE
Fix/int 859 level

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -887,13 +887,13 @@ class Client extends BaseClient
             }
             $enrichedData['stories'] = $stories;
         }
-        
+
         if (!empty($data['rels'])) {
             foreach ($data['rels'] as $index => $rel) {
                 $enrichedData['rels'][$index] = $this->enrichContent($rel, -1);
             }
         }
-        
+
         if (!empty($data['links'])) {
             foreach ($data['links'] as $index => $rel) {
                 $enrichedData['links'][$index] = $this->enrichContent($rel, -1);

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -657,6 +657,7 @@ class Client extends BaseClient
             $relations = $data['rels'];
         } elseif (isset($data['rel_uuids'])) {
             $relSize = \count($data['rel_uuids']);
+
             $chunks = [];
             $chunkSize = 50;
 
@@ -741,6 +742,7 @@ class Client extends BaseClient
     public function enrichContent($data, $level = 0)
     {
         $enrichedContent = $data;
+
         if (isset($data['component'])) {
             if (!$this->isStopResolving($level)) {
                 foreach ($data as $fieldName => $fieldValue) {
@@ -752,10 +754,8 @@ class Client extends BaseClient
         } elseif (\is_array($data)) {
             if (!$this->isStopResolving($level)) {
                 foreach ($data as $key => $value) {
-                    if (\is_string($value) && \array_key_exists($value, $this->resolvedRelations)) {
-                        if ('uuid' !== $key) {
-                            $enrichedContent[$key] = $this->resolvedRelations[$value];
-                        }
+                    if (\is_string($value) && \array_key_exists($value, $this->resolvedRelations) && 'uuid' !== $key) {
+                        $enrichedContent[$key] = $this->resolvedRelations[$value];
                     } else {
                         $enrichedContent[$key] = $this->enrichContent($value, $level + 1);
                     }
@@ -874,9 +874,9 @@ class Client extends BaseClient
         $this->getResolvedLinks($data, $queryString);
 
         if (isset($data['story'])) {
-            if (isset($enrichedData['rel_uuids'])) {
-                $enrichedData['rels'] = $this->resolvedRelations;
-            }
+            // if (isset($enrichedData['rel_uuids'])) {
+            //     $enrichedData['rels'] = $this->resolvedRelations;
+            // }
             $enrichedData['story']['content'] = $this->enrichContent($data['story']['content']);
         } elseif (isset($data['stories'])) {
             $stories = [];
@@ -913,7 +913,6 @@ class Client extends BaseClient
     private function insertRelations($component, $field, $value)
     {
         $filteredNode = $value;
-
         if (isset($this->_relationsList[$component]) && \in_array($field, $this->_relationsList[$component], true)) {
             if (\is_string($value)) {
                 if (isset($this->resolvedRelations[$value])) {
@@ -923,6 +922,7 @@ class Client extends BaseClient
             } elseif (\is_array($value)) {
                 $filteredNodeTemp = [];
                 $resolved = false;
+
                 foreach ($value as $item) {
                     if (\is_string($item) && isset($this->resolvedRelations[$item])) {
                         $resolved = true;
@@ -931,8 +931,13 @@ class Client extends BaseClient
                         $filteredNodeTemp[] = $story;
                     }
                 }
+
                 if ($resolved) {
-                    $filteredNode = $filteredNodeTemp;
+                    if (1 === \count($filteredNodeTemp)) {
+                        $filteredNode = $filteredNodeTemp[0];
+                    } else {
+                        $filteredNode = $filteredNodeTemp;
+                    }
                 }
             }
         }

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -749,7 +749,7 @@ class Client extends BaseClient
                     if (isset($fieldValue['_stopResolving']) && $fieldValue['_stopResolving']) {
                         continue;
                     }
-                    
+
                     $enrichedContent[$fieldName] = $this->insertRelations($data['component'], $fieldName, $fieldValue);
                     $enrichedContent[$fieldName] = $this->insertLinks($enrichedContent[$fieldName]);
                     $enrichedContent[$fieldName] = $this->enrichContent($enrichedContent[$fieldName], $level + 1);

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -905,9 +905,7 @@ class Client extends BaseClient
             if (\is_string($value)) {
                 if (isset($this->resolvedRelations[$value])) {
                     $filteredNode = $this->resolvedRelations[$value];
-                    $filteredNode['_stopResolving'] = $this->getLevelResolving($filteredNode) + 1;
-                    // $this->settingStopResolving($filteredNode);
-                    // $filteredNode['_stopResolving'] = true;
+                    $this->settingStopResolving($filteredNode);
                 }
             } elseif (\is_array($value)) {
                 $filteredNodeTemp = [];
@@ -916,10 +914,7 @@ class Client extends BaseClient
                     if (\is_string($item) && isset($this->resolvedRelations[$item])) {
                         $resolved = true;
                         $story = $this->resolvedRelations[$item];
-
-                        // $story['_stopResolving'] = true;
-                        // $this->settingStopResolving($story);
-                        $story['_stopResolving'] = $this->getLevelResolving($story) + 1;
+                        $this->settingStopResolving($story);
                         $filteredNodeTemp[] = $story;
                     }
                 }
@@ -1085,12 +1080,11 @@ class Client extends BaseClient
         return hash('sha256', $key);
     }
 
-/*
     private function settingStopResolving(&$data)
     {
         $data['_stopResolving'] = $this->getLevelResolving($data) + 1;
     }
-*/
+
     private function isStopResolving($data)
     {
         return $this->getLevelResolving($data) > 2;

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -887,6 +887,18 @@ class Client extends BaseClient
             }
             $enrichedData['stories'] = $stories;
         }
+        
+        if (!empty($data['rels'])) {
+            foreach ($data['rels'] as $index => $rel) {
+                $enrichedData['rels'][$index] = $this->enrichContent($rel, -1);
+            }
+        }
+        
+        if (!empty($data['links'])) {
+            foreach ($data['links'] as $index => $rel) {
+                $enrichedData['links'][$index] = $this->enrichContent($rel, -1);
+            }
+        }
 
         return $enrichedData;
     }
@@ -1088,6 +1100,6 @@ class Client extends BaseClient
 
     private function isStopResolving($level)
     {
-        return $level > 3;
+        return $level > 4;
     }
 }

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -746,6 +746,10 @@ class Client extends BaseClient
         if (isset($data['component'])) {
             if (!$this->isStopResolving($level)) {
                 foreach ($data as $fieldName => $fieldValue) {
+                    if (isset($fieldValue['_stopResolving']) && $fieldValue['_stopResolving']) {
+                        continue;
+                    }
+                    
                     $enrichedContent[$fieldName] = $this->insertRelations($data['component'], $fieldName, $fieldValue);
                     $enrichedContent[$fieldName] = $this->insertLinks($enrichedContent[$fieldName]);
                     $enrichedContent[$fieldName] = $this->enrichContent($enrichedContent[$fieldName], $level + 1);
@@ -754,8 +758,10 @@ class Client extends BaseClient
         } elseif (\is_array($data)) {
             if (!$this->isStopResolving($level)) {
                 foreach ($data as $key => $value) {
-                    if (\is_string($value) && \array_key_exists($value, $this->resolvedRelations) && 'uuid' !== $key) {
-                        $enrichedContent[$key] = $this->resolvedRelations[$value];
+                    if (\is_string($value) && \array_key_exists($value, $this->resolvedRelations)) {
+                        if ('uuid' !== $key) {
+                            $enrichedContent[$key] = $this->resolvedRelations[$value];
+                        }
                     } else {
                         $enrichedContent[$key] = $this->enrichContent($value, $level + 1);
                     }
@@ -933,11 +939,7 @@ class Client extends BaseClient
                 }
 
                 if ($resolved) {
-                    if (1 === \count($filteredNodeTemp)) {
-                        $filteredNode = $filteredNodeTemp[0];
-                    } else {
-                        $filteredNode = $filteredNodeTemp;
-                    }
+                    $filteredNode = $filteredNodeTemp;
                 }
             }
         }

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -305,10 +305,12 @@ test('Integration: test stop resolving loop', function () {
     );
     $responses = $client->getStoryBySlug($slug);
     $body = $responses->getBody();
+
     expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
     expect($body['story']['content']['related'])->toBeArray();
-    expect($body['story']['content']['related']['name'])->toEqual('TestLevel2'); // FIRST LEVEL
+    expect($body['story']['content']['related']['name'])->toEqual('TestLevel2');
     expect($body['story']['content']['related']['_stopResolving'])->toEqual(1);
-    expect($body['story']['content']['related']['content']['related']['name'])->toEqual('TestLevel'); // SECOND LEVEL
-    expect($body['story']['content']['related']['content']['related']['content']['related'])->toBeString(); // NO RESOLVING THIRD LEVEL
+    expect($body['story']['content']['related']['content']['related']['name'])->toEqual('TestLevel');
+    expect($body['story']['content']['related']['content']['related']['content']['related'])->toBeArray();
+    expect($body['story']['content']['related']['content']['related']['content']['related']['content']['related'])->toBeString();
 })->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -142,7 +142,7 @@ test('Integration: get one story with Resolved relations 1', function () {
     );
     $responses = $client->getStoryBySlug($slug);
     $body = $responses->getBody();
-    expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
+    expect($body)->toHaveKeys(['rel_uuids', 'story', 'cv', 'links']);
     expect($body['story']['content']['FeaturedCategoryProducts'])->toBeArray();
     expect($body['story']['content']['FeaturedCategoryProducts']['0']['name'])->toEqual('Category 001');
     expect($body['story']['content']['FeaturedCategoryProducts']['1']['name'])->toEqual('Category A');
@@ -151,7 +151,7 @@ test('Integration: get one story with Resolved relations 1', function () {
     expect($body['story']['content']['MainProduct'])->toBeArray();
     expect($body['story']['content']['MainProduct']['name'])->toEqual('Bike 001');
     expect($body['story']['content']['MainProduct']['content']['ProductVariants'])->toBeArray()->toHaveLength(2);
-    expect($body['rels'])->toHaveLength(51);
+    expect($body['rel_uuids'])->toHaveLength(51);
 })->group('integration');
 
 test('Integration: get one story with few resolved relations', function () {
@@ -168,13 +168,12 @@ test('Integration: get one story with few resolved relations', function () {
     $body = $responses->getBody();
     expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
     expect($body['story']['content']['Products'])->toBeArray();
-    expect($body['story']['content']['Products'])->toHaveCount(1);
-    expect($body['story']['content']['Products']['0']['content']['productname'])->toEqual('Shoe 001');
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0'])->toBeArray();
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['name'])->toEqual('Shoe 001 Blue');
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content'])->toBeArray();
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
+    expect($body['story']['content']['Products']['content']['productname'])->toEqual('Shoe 001');
+    expect($body['story']['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['story']['content']['Products']['content']['ProductVariants']['0'])->toBeArray();
+    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['name'])->toEqual('Shoe 001 Blue');
+    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['content'])->toBeArray();
+    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
     expect($body['rels'])->toHaveLength(4);
 })->group('integration');
 
@@ -244,10 +243,9 @@ test('Integration: get list of stories story with Resolved relations 2', functio
     expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
 
     expect($body['stories'][0]['content']['Products'])->toBeArray();
-    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
-    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
-    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
+    expect($body['stories'][0]['content']['Products']['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
 })->group('integration');
 
 test('Integration: get list of stories -translations- story with Resolved relations 2', function () {
@@ -271,10 +269,9 @@ test('Integration: get list of stories -translations- story with Resolved relati
     expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
 
     expect($body['stories'][0]['content']['Products'])->toBeArray();
-    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
-    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
-    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Scarpa 001 Blu');
+    expect($body['stories'][0]['content']['Products']['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Scarpa 001 Blu');
 })->group('integration');
 
 test('Integration: get one story with Resolved relations 3', function () {

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -194,6 +194,7 @@ test('Integration: get one story from Product', function () {
     expect($body['story']['content']['ProductVariants'])->toHaveLength(2);
     expect($body['story']['content']['ProductVariants']['0']['name'])->toBeString();
     expect($body['story']['content']['ProductVariants']['0']['name'])->toEqual('Bike 001 L');
+    expect($body['story']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Bike 001 L');
 })->group('integration');
 
 test('Integration: get one story with Resolved relations 2', function () {
@@ -217,6 +218,7 @@ test('Integration: get one story with Resolved relations 2', function () {
     expect($body['story']['content']['MainProduct'])->toBeArray();
     expect($body['story']['content']['MainProduct']['name'])->toEqual('Bike 001');
     expect($body['story']['content']['MainProduct']['content']['ProductVariants'])->toBeArray()->toHaveLength(2);
+    expect($body['story']['content']['MainProduct']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Bike 001 L');
 })->group('integration');
 
 test('Integration: get one story with Resolved relations 3', function () {

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -151,6 +151,26 @@ test('Integration: get one story with Resolved relations 1', function () {
     expect($body['rels'])->toHaveLength(51);
 })->group('integration');
 
+test('Integration: get one story with few resolved relations', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');
+    $slug = 'categories/category-shoe-001';
+    $key = 'stories/' . $slug;
+    $client->editMode();
+    $options = $client->getApiParameters();
+    $client->resolveRelations(
+        'ProductCategory.Products,Product.ProductVariants'
+    );
+    $responses = $client->getStoryBySlug($slug);
+    $body = $responses->getBody();
+    expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
+    expect($body['story']['content']['Products'])->toBeArray();
+    expect($body['story']['content']['Products'])->toHaveCount(1);
+    expect($body['story']['content']['Products']['0']['content']['productname'])->toEqual('Shoe 001');
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['rels'])->toHaveLength(4);
+})->group('integration');
+
 test('Integration: get one story from Product', function () {
     unset($_GET['_storyblok_published']);
     $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -68,20 +68,17 @@ test('Integration: check casting after enriching content', function () {
     $body = $response->getBody();
     expect($body)->toBeArray()
         ->toHaveKey('story')
-        ->toHaveCount(4)
-    ;
+        ->toHaveCount(4);
     $story = $body['story'];
     expect($story)->toBeArray()
         ->toHaveKey('content')
-        ->toHaveCount(22)
-    ;
+        ->toHaveCount(22);
     $content = $story['content'];
     expect($content)->toBeArray()
         ->toHaveKey('_uid')
         ->toHaveKey('body')
         ->toHaveKey('component')
-        ->toHaveCount(4)
-    ;
+        ->toHaveCount(4);
     expect($content['_uid'])->toBeString();
     expect($content['component'])->toBeString();
 })->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -169,9 +169,9 @@ test('Integration: get one story with few resolved relations', function () {
     expect($body['story']['content']['Products']['0']['content']['productname'])->toEqual('Shoe 001');
     expect($body['story']['content']['Products']['0']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
     expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0'])->toBeArray();
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['name'])->toEqual("Shoe 001 Blue");
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['name'])->toEqual('Shoe 001 Blue');
     expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content'])->toBeArray();
-    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual("Shoe 001 Blue");;
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
     expect($body['rels'])->toHaveLength(4);
 })->group('integration');
 

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -154,6 +154,27 @@ test('Integration: get one story with Resolved relations 1', function () {
     expect($body['rels'])->toHaveLength(51);
 })->group('integration');
 
+test('Integration: get one story from Product', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');
+    $slug = 'categories/products/bike-001';
+    $key = 'stories/' . $slug;
+    $client->editMode();
+    $options = $client->getApiParameters();
+    $client->resolveRelations(
+        'Product.ProductVariants'
+    );
+    $responses = $client->getStoryBySlug($slug);
+    $body = $responses->getBody();
+    expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
+    // print_r($body);
+    expect($body['story']['content']['productname'])->toEqual('Bike 001');
+    expect($body['story']['content']['ProductVariants'])->toBeArray();
+    expect($body['story']['content']['ProductVariants'])->toHaveLength(2);
+    expect($body['story']['content']['ProductVariants']['0']['name'])->toBeString();
+    expect($body['story']['content']['ProductVariants']['0']['name'])->toEqual('Bike 001 L');
+})->group('integration');
+
 test('Integration: get one story with Resolved relations 2', function () {
     unset($_GET['_storyblok_published']);
     $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -292,3 +292,23 @@ test('Integration: get one story with Resolved relations 3', function () {
     expect($body['story']['content']['ProductVariants']['0']['name'])->toBeString();
     expect($body['story']['content']['ProductVariants']['1']['name'])->toBeString();
 })->group('integration');
+
+test('Integration: test stop resolving loop', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');
+    $slug = 'testlevel';
+    $key = 'stories/' . $slug;
+    $client->editMode();
+    $options = $client->getApiParameters();
+    $client->resolveRelations(
+        'level-1.related,level-2.related'
+    );
+    $responses = $client->getStoryBySlug($slug);
+    $body = $responses->getBody();
+    expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
+    expect($body['story']['content']['related'])->toBeArray();
+    expect($body['story']['content']['related']['name'])->toEqual('TestLevel2'); // FIRST LEVEL
+    expect($body['story']['content']['related']['_stopResolving'])->toEqual(1);
+    expect($body['story']['content']['related']['content']['related']['name'])->toEqual('TestLevel'); // SECOND LEVEL
+    expect($body['story']['content']['related']['content']['related']['content']['related'])->toBeString(); // NO RESOLVING THIRD LEVEL
+})->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -247,6 +247,33 @@ test('Integration: get list of stories story with Resolved relations 2', functio
     expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
 })->group('integration');
 
+test('Integration: get list of stories -translations- story with Resolved relations 2', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');
+
+    $key = 'stories/';
+    $params = [
+        'starts_with' => 'categories/category-shoe',
+        'content_type' => 'ProductCategory',
+    ];
+    $client->editMode();
+    $client->language('it');
+    $options = $client->getApiParameters();
+    $client->resolveRelations(
+        'ProductCategory.Products,Product.ProductVariants'
+    );
+    $responses = $client->getStories($params);
+    $body = $responses->getBody();
+    expect($body)->toHaveKeys(['rels', 'stories', 'cv', 'links']);
+    expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
+
+    expect($body['stories'][0]['content']['Products'])->toBeArray();
+    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
+    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Scarpa 001 Blu');
+})->group('integration');
+
 test('Integration: get one story with Resolved relations 3', function () {
     unset($_GET['_storyblok_published']);
     $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -168,6 +168,10 @@ test('Integration: get one story with few resolved relations', function () {
     expect($body['story']['content']['Products'])->toHaveCount(1);
     expect($body['story']['content']['Products']['0']['content']['productname'])->toEqual('Shoe 001');
     expect($body['story']['content']['Products']['0']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0'])->toBeArray();
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['name'])->toEqual("Shoe 001 Blue");
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content'])->toBeArray();
+    expect($body['story']['content']['Products']['0']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual("Shoe 001 Blue");;
     expect($body['rels'])->toHaveLength(4);
 })->group('integration');
 

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -68,17 +68,20 @@ test('Integration: check casting after enriching content', function () {
     $body = $response->getBody();
     expect($body)->toBeArray()
         ->toHaveKey('story')
-        ->toHaveCount(4);
+        ->toHaveCount(4)
+    ;
     $story = $body['story'];
     expect($story)->toBeArray()
         ->toHaveKey('content')
-        ->toHaveCount(22);
+        ->toHaveCount(22)
+    ;
     $content = $story['content'];
     expect($content)->toBeArray()
         ->toHaveKey('_uid')
         ->toHaveKey('body')
         ->toHaveKey('component')
-        ->toHaveCount(4);
+        ->toHaveCount(4)
+    ;
     expect($content['_uid'])->toBeString();
     expect($content['component'])->toBeString();
 })->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -221,6 +221,32 @@ test('Integration: get one story with Resolved relations 2', function () {
     expect($body['story']['content']['MainProduct']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Bike 001 L');
 })->group('integration');
 
+test('Integration: get list of stories story with Resolved relations 2', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');
+
+    $key = 'stories/';
+    $params = [
+        'starts_with' => 'categories/category-shoe',
+        'content_type' => 'ProductCategory',
+    ];
+    $client->editMode();
+    $options = $client->getApiParameters();
+    $client->resolveRelations(
+        'ProductCategory.Products,Product.ProductVariants'
+    );
+    $responses = $client->getStories($params);
+    $body = $responses->getBody();
+    expect($body)->toHaveKeys(['rels', 'stories', 'cv', 'links']);
+    expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
+
+    expect($body['stories'][0]['content']['Products'])->toBeArray();
+    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
+    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
+})->group('integration');
+
 test('Integration: get one story with Resolved relations 3', function () {
     unset($_GET['_storyblok_published']);
     $client = new Client('HMqBPn2a92FjXYI3tQGDVQtt');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -168,12 +168,13 @@ test('Integration: get one story with few resolved relations', function () {
     $body = $responses->getBody();
     expect($body)->toHaveKeys(['rels', 'story', 'cv', 'links']);
     expect($body['story']['content']['Products'])->toBeArray();
-    expect($body['story']['content']['Products']['content']['productname'])->toEqual('Shoe 001');
-    expect($body['story']['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['story']['content']['Products']['content']['ProductVariants']['0'])->toBeArray();
-    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['name'])->toEqual('Shoe 001 Blue');
-    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['content'])->toBeArray();
-    expect($body['story']['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
+    expect($body['story']['content']['Products'])->toHaveLength(1);
+    expect($body['story']['content']['Products'][0]['content']['productname'])->toEqual('Shoe 001');
+    expect($body['story']['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['story']['content']['Products'][0]['content']['ProductVariants']['0'])->toBeArray();
+    expect($body['story']['content']['Products'][0]['content']['ProductVariants']['0']['name'])->toEqual('Shoe 001 Blue');
+    expect($body['story']['content']['Products'][0]['content']['ProductVariants']['0']['content'])->toBeArray();
+    expect($body['story']['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
     expect($body['rels'])->toHaveLength(4);
 })->group('integration');
 
@@ -243,9 +244,10 @@ test('Integration: get list of stories story with Resolved relations 2', functio
     expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
 
     expect($body['stories'][0]['content']['Products'])->toBeArray();
-    expect($body['stories'][0]['content']['Products']['name'])->toEqual('Shoe 001');
-    expect($body['stories'][0]['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['stories'][0]['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
+    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
+    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Shoe 001 Blue');
 })->group('integration');
 
 test('Integration: get list of stories -translations- story with Resolved relations 2', function () {
@@ -269,9 +271,10 @@ test('Integration: get list of stories -translations- story with Resolved relati
     expect($body['stories'][0]['name'])->toEqual('Category Shoe 001');
 
     expect($body['stories'][0]['content']['Products'])->toBeArray();
-    expect($body['stories'][0]['content']['Products']['name'])->toEqual('Shoe 001');
-    expect($body['stories'][0]['content']['Products']['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
-    expect($body['stories'][0]['content']['Products']['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Scarpa 001 Blu');
+    expect($body['stories'][0]['content']['Products'])->toHaveLength(1);
+    expect($body['stories'][0]['content']['Products'][0]['name'])->toEqual('Shoe 001');
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants'])->toBeArray()->toHaveLength(3);
+    expect($body['stories'][0]['content']['Products'][0]['content']['ProductVariants']['0']['content']['VariantName'])->toEqual('Scarpa 001 Blu');
 })->group('integration');
 
 test('Integration: get one story with Resolved relations 3', function () {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- If it's an internal request, please add the Jira link. -->
Jira Link: INT-859



- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

Resolving nested relations.

This PR introduces the feature to resolve nested relations, tracking the level for enrichContent() method

For testing:
```
composer run test
```
Especially take a look at tests:
- Nested relations ( less than 50): "Integration: get one story with few resolved relations" 
- Nested relations: "Integration: get one story with Resolved relations 1"
- Nested relations (more than 50):"Integration: get one story with Resolved relations 2"
- Nested translated relations :"Integration: get list of stories -translations- story with Resolved relations 2"
- Nested relatins for multiple stories: "Integration: get list of stories story with Resolved relations 2"
- Auto referenced stories (avoid infinite loop): "Integration: test stop resolving loop"
- 
in the file `tests/Storyblok/Integration/ClientTest.php`


