### PR TITLE
fix: set from_release parameter in getStories if release is set for client

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -423,6 +423,10 @@ class Client extends BaseClient
                 $options['resolve_links'] = $this->resolveLinks;
             }
 
+            if ($this->release) {
+                $options['from_release'] = $this->release;
+            }
+
             $response = $this->get($endpointUrl, $options);
 
             $this->_save($response, $cacheKey, $this->getVersion());


### PR DESCRIPTION
## Pull request type

<!-- If it's an internal request, please add the Jira link. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Create a release and copy the ID.
Execute the Code below:
```php
$client = new Client('API key');
$client->setRelease('Release id');
$options = [
  // Slug of a page with changed content in the release
  'by_slugs' => 'slug'
];
$client->getStories($options);
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
When fetching data from Storyblok using the getStories function the release string set for the client is now respected.

## Other information
Fixes #92 